### PR TITLE
Fix and further clarify the holochain gym link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Holochain Gym - Developer Exercises
 
-These are code exercises for the developer part of the [holochain gym](http://localhost:8000/developers/).
+These are code exercises for the [developer part of the holochain gym](https://holochain-gym.github.io/developers/).
 
 To get started, clone this repository and follow the guides on the gym to complete the exercises from this repository.


### PR DESCRIPTION
The holochain gym link was directing to locahost so this fixes that.
Also increased the text the link covers to further clarify that the link is to the developer part of the holochain gym, not the whole gym.