### PR TITLE
Align gym code with gym documentation

### DIFF
--- a/basic/0.entries/zomes/exercise/src/lib.rs
+++ b/basic/0.entries/zomes/exercise/src/lib.rs
@@ -7,7 +7,7 @@ pub struct SomeExternalInput {
     content: String,
 }
 
-#[hdk_extern()]
+
 pub fn say_greeting(input: SomeExternalInput) -> ExternResult<HeaderHash> {
     unimplemented!()
 }


### PR DESCRIPTION
In the documentation for the gym exercise it says the line '#[hdk_extern()]' is not there and to add it. 
So both where it says what code is provided and what to do are not aligned with the actual code you get.
This pull requests fixes that by aligning the code provided with the text in the tutorial.