### PR TITLE
Fix links tests

### DIFF
--- a/1.basic/3.links/exercise/tests/package.json
+++ b/1.basic/3.links/exercise/tests/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@holochain/tryorama": "0.4.0",
+    "@holochain/tryorama": "0.4.1",
     "@msgpack/msgpack": "^2.3.0",
     "@types/lodash": "^4.14.158",
     "@types/node": "^14.0.14",


### PR DESCRIPTION
`0.4.0` produces config with a missing network field, breaking tests. Upgrading to `0.4.1` fixes the issue
```bash
20:15:05 info:
☉☉☉ [[[CONDUCTOR c0]]]
☉
☉ The specified config file (/tmp/tmp.7fPZWdlwgr/tryorama/DRTwZF/conductor-config.yml)
☉ could not be parsed, because it is not valid YAML. Please check and fix the
☉ file, or delete the file and run the conductor again with the -i flag to create
☉ a valid default configuration. Details:
☉
☉     network: missing field `network_type` at line 2 column 17
☉
☉
☉
20:15:05 [tryorama] info: conductor 'c0' exited with code 42
20:15:05 [tryorama] error: Test error: 'Conductor exited before starting interface (code 42)'
not ok 1 Test threw an exception. See output for details.
  ---
    operator: fail
    at: <anonymous> (/home/alexc/Holochain/coreconcepts/developer-exercises/1.basic/3.links/exercise/tests/node_modules/@holochain/tryorama/src/middleware.ts:137:13)
    stack: |-
      Error: Test threw an exception. See output for details.
          at Test.assert [as _assert] (/home/alexc/Holochain/coreconcepts/developer-exercises/1.basic/3.links/exercise/tests/node_modules/tape/lib/test.js:269:54)
          at Test.bound [as _assert] (/home/alexc/Holochain/coreconcepts/developer-exercises/1.basic/3.links/exercise/tests/node_modules/tape/lib/test.js:90:32)
          at Test.fail (/home/alexc/Holochain/coreconcepts/developer-exercises/1.basic/3.links/exercise/tests/node_modules/tape/lib/test.js:363:10)
          at Test.bound [as fail] (/home/alexc/Holochain/coreconcepts/developer-exercises/1.basic/3.links/exercise/tests/node_modules/tape/lib/test.js:90:32)
          at /home/alexc/Holochain/coreconcepts/developer-exercises/1.basic/3.links/exercise/tests/node_modules/@holochain/tryorama/src/middleware.ts:137:13
          at processTicksAndRejections (internal/process/task_queues.js:97:5)
  ...
```