### PR TITLE
fix(test): Add build commands when run npm test

### DIFF
--- a/1.basic/4.source-chain/exercise/tests/package.json
+++ b/1.basic/4.source-chain/exercise/tests/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "TRYORAMA_LOG_LEVEL=info WASM_LOG=warn RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts"
+    "test": "npm run check-nix && npm run build && npm run pack && TRYORAMA_LOG_LEVEL=info RUST_LOG=error WASM_LOG=warn RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts",
+    "check-nix": "./../../../../check_running_in_gym_nix_shell.sh",
+    "build": "cd .. && CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown",
+    "pack": "hc dna pack ../workdir"
   },
   "author": "",
   "license": "ISC",

--- a/1.basic/4.source-chain/solution/tests/package.json
+++ b/1.basic/4.source-chain/solution/tests/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "TRYORAMA_LOG_LEVEL=info WASM_LOG=warn RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts"
+    "test": "npm run check-nix && npm run build && npm run pack && TRYORAMA_LOG_LEVEL=info RUST_LOG=error WASM_LOG=warn RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts",
+    "check-nix": "./../../../../check_running_in_gym_nix_shell.sh",
+    "build": "cd .. && CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown",
+    "pack": "hc dna pack ../workdir"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
On the "1.basics > 4.source-chain" the tests didn't have the build commands. I added it.