### PR TITLE
Fix(tests fail): Increase sleep between tests.

### DIFF
--- a/1.basic/3.links/exercise/tests/src/index.ts
+++ b/1.basic/3.links/exercise/tests/src/index.ts
@@ -59,7 +59,7 @@ orchestrator.registerScenario(
     t.ok(entry_1);
     t.ok(entry_2);
 
-    await sleep(100);
+    await sleep(2000);
 
     let posts = await alice_common.cells[0].call(
       "exercise",
@@ -97,7 +97,7 @@ orchestrator.registerScenario(
     });
 
     t.ok(entry_3);
-    await sleep(100);
+    await sleep(2000);
 
     let bob_posts = await alice_common.cells[0].call(
       "exercise",


### PR DESCRIPTION
On the 1. basic / 3. links / exercise, the tests 4, 7 and 8 fails.
The diff between both exercise/test/src/index.ts and exercise/test/src/index.ts is the time on the "await sleep()" command.
After increase from 100 to 2000 the tests pass.

Why is necessary to increase sleep time?