### PR TITLE
fixed function naming in 2.intermediate/1.paths/exercise

### DIFF
--- a/2.intermediate/1.paths/exercise/zomes/exercise/src/lib.rs
+++ b/2.intermediate/1.paths/exercise/zomes/exercise/src/lib.rs
@@ -24,7 +24,7 @@ pub struct GetPostsByTimeInput {
     hour: Option<usize>,
 }
 #[hdk_extern]
-pub fn get_post_by_time(input: GetPostsByTimeInput) -> ExternResult<Vec<Post>> {
+pub fn get_posts_by_time(input: GetPostsByTimeInput) -> ExternResult<Vec<Post>> {
     unimplemented!()
 }
 


### PR DESCRIPTION
Fixed the following error that occured during testing of 2.intermediate/1.paths

```
[tryorama] error: Test error: {
  type: 'error',
  data: {
    type: 'ribosome_error',
    data: "Attempted to call a zome function that doesn't exist: Zome: exercise Fn get_posts_by_time"
  }
```