### PR TITLE
fixed test command in package.json of 2.intermediate/5.capability-tokens

### DIFF
--- a/2.intermediate/5.capability-tokens/exercise/tests/package.json
+++ b/2.intermediate/5.capability-tokens/exercise/tests/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "TRYORAMA_LOG_LEVEL=error RUST_LOG=debug RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts"
+    "test": "npm run check-nix && npm run build && npm run pack && TRYORAMA_LOG_LEVEL=info RUST_LOG=error WASM_LOG=warn RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts",
+    "check-nix": "./../../../../check_running_in_gym_nix_shell.sh",
+    "build": "cd .. && CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown",
+    "pack": "hc dna pack ../workdir"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
The `npm test` command was not working properly in `2.intermediate/5.capability-tokens/exercise/tests`. It seems that the test command in the `package.json` was not defined correctly. After my changes, the tests ran properly as far as I can judge.
