### PR TITLE
Add hint to fix rust-analyzer issue directly in code

### DIFF
--- a/1.basic/0.zome-functions/exercise/zomes/exercise/src/lib.rs
+++ b/1.basic/0.zome-functions/exercise/zomes/exercise/src/lib.rs
@@ -1,6 +1,12 @@
 
 // Problem statement: https://holochain-gym.github.io/developers/basic/zome-functions/
 
+/// HINT: If your rust-analyzer throws the error "rust-analyzer failed to discover workspace",
+/// this is because the folder you have currently open in VSCode (most probably the
+/// "developer-exercises" folder) does not contain a "Cargo.toml" file.
+/// Open the folder "1.basic/0.zome-functions/exercise" (which *does* contain a Cargo.toml file) in a separate VSCode
+/// window to get the rust-analyzer running.
+
 pub struct SomeExternalInput {
     first_name: String,
     last_name: String,
@@ -11,16 +17,16 @@ pub struct SomeExternalOutput(String);
 pub fn hello_world(_:()) -> ExternResult<SomeExternalOutput> {
     let message: String = String::from("Hello world");
     let output: SomeExternalOutput = SomeExternalOutput(message);
-    
+
     Ok(output)
 }
 
 pub fn say_my_name(external_input:SomeExternalInput) -> ExternResult<SomeExternalOutput> {
-    let message: String = format!("Your name is {} {}", 
-                                    external_input.first_name, 
+    let message: String = format!("Your name is {} {}",
+                                    external_input.first_name,
                                     external_input.last_name);
     let output: SomeExternalOutput = SomeExternalOutput(message);
-    
+
     Ok(output)
 }
 

--- a/2.intermediate/5.capability-tokens/exercise/tests/package.json
+++ b/2.intermediate/5.capability-tokens/exercise/tests/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "TRYORAMA_LOG_LEVEL=error RUST_LOG=debug RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts"
+    "test": "npm run check-nix && npm run build && npm run pack && TRYORAMA_LOG_LEVEL=info RUST_LOG=error WASM_LOG=warn RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts",
+    "check-nix": "./../../../../check_running_in_gym_nix_shell.sh",
+    "build": "cd .. && CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown",
+    "pack": "hc dna pack ../workdir"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
The recommendation in the "requirements" section to open the exercise from a folder containing a `Cargo.toml` file is easily overlooked. Adding a hint directly in the code of the first exercise might save people some time :).

Some trailing white spaces have been removed as well by this commit due to my VSCode settings...