### PR TITLE
Improve remote call exercise solution

### DIFF
--- a/2.intermediate/4.remote-call/exercise/tests/package.json
+++ b/2.intermediate/4.remote-call/exercise/tests/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run build && npm run pack && TRYORAMA_LOG_LEVEL=info RUST_LOG=error WASM_LOG=warn RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts",
-    
-    "build": "cd ../zomes/exercise && cargo build --release --target wasm32-unknown-unknown",    "pack": "hc dna pack ../workdir"
+    "build": "cd ../zomes/exercise && cargo build --release --target wasm32-unknown-unknown",
+    "pack": "hc dna pack ../workdir"
   },
   "author": "",
   "license": "ISC",

--- a/2.intermediate/4.remote-call/exercise/tests/src/index.ts
+++ b/2.intermediate/4.remote-call/exercise/tests/src/index.ts
@@ -36,9 +36,8 @@ orchestrator.registerScenario(
 
     let capGrant = await alice_common.cells[0].call(
       "exercise",
-      "create_cap_access",
+      "grant_p2p_message_cap",
       {
-        function: "receive_p2p_message",
         agent: bob_common.agent,
       }
     );
@@ -47,9 +46,8 @@ orchestrator.registerScenario(
     
     let capGrantBob = await bob_common.cells[0].call(
       "exercise",
-      "create_cap_access",
+      "grant_p2p_message_cap",
       {
-        function: "receive_p2p_message",
         agent: alice_common.agent,
       }
     );
@@ -59,9 +57,9 @@ orchestrator.registerScenario(
     //Create p2p post to bob
     let p2pPost2Bob = await alice_common.cells[0].call(
       "exercise",
-      "create_post",
+      "send_message",
       {
-        content: "Hey Bob!",
+        message: "Hey Bob!",
         target_agent: bob_common.agent,
       }
     );
@@ -71,7 +69,7 @@ orchestrator.registerScenario(
     //Check that bob has the p2p post
     let bobMessages = await bob_common.cells[0].call(
       "exercise",
-      "get_my_posts",
+      "get_messages",
       null
     );
     console.log(bobMessages);
@@ -81,9 +79,9 @@ orchestrator.registerScenario(
     //Create p2p post to alice
     let p2pPost2Alice = await bob_common.cells[0].call(
       "exercise",
-      "create_post",
+      "send_message",
       {
-        content: "Hey Alice!",
+        message: "Hey Alice!",
         target_agent: alice_common.agent,
       }
     );
@@ -93,26 +91,28 @@ orchestrator.registerScenario(
     //Check that alice has the p2p post
     let aliceMessages = await alice_common.cells[0].call(
       "exercise",
-      "get_my_posts",
+      "get_messages",
       null
     );
     console.log(aliceMessages);
     t.ok(aliceMessages);
     t.equal(aliceMessages.length, 1);
     
-    //Check that clare cannot message alice since she does not have cap access
-        // TODO add test that validates if the async function throws error
-        // -- commenting this out to make the CI build pass
-    // let p2pPost2Alice2 = await clare_common.cells[0].call(
-    //   "exercise",
-    //   "create_post",
-    //   {
-    //     content: "Hey Alice!",
-    //     target_agent: alice_common.agent,
-    //   }
-    // );
-    // console.log(p2pPost2Alice2);
-    // t.equal(p2pPost2Alice2.Err)
+    // Check that clare cannot message alice since she does not have cap access
+    try {
+      await clare_common.cells[0].call(
+        "exercise",
+        "send_unauthorized_message",
+        {
+          message: "Hey Alice!",
+          target_agent: alice_common.agent,
+        }
+      );
+      t.fail("The call should not have succeeded.");
+    } catch (err) {
+      console.log({err});
+      t.ok(err.data.data.includes("Unauthorized"));
+    }
   }
 );
 

--- a/2.intermediate/4.remote-call/exercise/zomes/exercise/src/lib.rs
+++ b/2.intermediate/4.remote-call/exercise/zomes/exercise/src/lib.rs
@@ -1,55 +1,68 @@
 use hdk::prelude::*;
 
-entry_defs![Post::entry_def()];
-
-#[hdk_entry(id = "post", visibility = "private")]
-#[derive(Clone)]
-pub struct Post(String);
-
-#[hdk_extern]
-fn init(_: ()) -> ExternResult<InitCallbackResult> {
-    unimplemented!();
-}
+entry_defs![Message::entry_def()];
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct CreatePostInput {
-    content: String,
-    target_agent: AgentPubKey,
-}
-
-#[hdk_extern]
-pub fn create_post(_create_input: CreatePostInput) -> ExternResult<CreatePostInput> {
-    unimplemented!();
-}
-
-#[hdk_extern]
-pub fn receive_p2p_message(_post: Post) -> ExternResult<()> {
-    unimplemented!()
-}
-
-#[hdk_extern]
-pub fn get_my_posts(_: ()) -> ExternResult<Vec<Post>> {
-    unimplemented!()
+pub struct GrantPeerMessageCapInput {
+    pub agent: AgentPubKey,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CapReceive {
+pub struct CapSecretInput {
     pub cap_secret: CapSecret,
-    pub from_agent: AgentPubKey
-}
-
-#[hdk_extern]
-pub fn receive_cap_access(_cap: CapReceive) -> ExternResult<()> {
-    unimplemented!()
+    pub from_agent: AgentPubKey,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct GrantCapAccess {
-    pub function: String,
-    pub agent: AgentPubKey
+pub struct SendMessageInput {
+    message: Message,
+    target_agent: AgentPubKey,
+}
+
+/// A message from one agent to another
+#[hdk_entry(id = "post", visibility = "private")]
+#[derive(Clone)]
+pub struct Message(String);
+
+#[hdk_extern]
+fn init(_: ()) -> ExternResult<InitCallbackResult> {
+    unimplemented!()
+}
+
+/// Directs this Agent to grant `input.agent` the capability to send messages
+#[hdk_extern]
+pub fn grant_peer_message_cap(input: GrantPeerMessageCapInput) -> ExternResult<GrantPeerMessageCapInput> {
+    unimplemented!()
+}
+
+/// Receive the capability to message another agent.
+/// 
+/// Any agent can call this zome function.
+#[hdk_extern]
+pub fn receive_peer_message_cap_secret(input: CapSecretInput) -> ExternResult<()> {
+    unimplemented!()
+}
+
+/// Sends a remote message with the given content and recipient
+#[hdk_extern]
+pub fn send_message(input: SendMessageInput) -> ExternResult<SendMessageInput> {
+    unimplemented!()
+}
+
+/// Sends a remote message without valid CapClaim
+/// 
+/// This is just for testing.
+#[hdk_extern]
+pub fn send_unauthorized_message(input: SendMessageInput) -> ExternResult<SendMessageInput> {
+    unimplemented!()
 }
 
 #[hdk_extern]
-pub fn create_cap_access(_access: GrantCapAccess) -> ExternResult<GrantCapAccess> {
+pub fn receive_peer_message(message: Message) -> ExternResult<()> {
+    unimplemented!()
+}
+
+#[hdk_extern]
+pub fn get_messages(_: ()) -> ExternResult<Vec<Message>> {
     unimplemented!()
 }

--- a/2.intermediate/4.remote-call/solution/tests/package.json
+++ b/2.intermediate/4.remote-call/solution/tests/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run build && npm run pack && TRYORAMA_LOG_LEVEL=info RUST_LOG=error WASM_LOG=warn RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts",
-    
-    "build": "cd ../zomes/exercise && cargo build --release --target wasm32-unknown-unknown",    "pack": "hc dna pack ../workdir"
+    "build": "cd ../zomes/exercise && cargo build --release --target wasm32-unknown-unknown", 
+    "pack": "hc dna pack ../workdir"
   },
   "author": "",
   "license": "ISC",

--- a/2.intermediate/4.remote-call/solution/tests/src/index.ts
+++ b/2.intermediate/4.remote-call/solution/tests/src/index.ts
@@ -36,9 +36,8 @@ orchestrator.registerScenario(
 
     let capGrant = await alice_common.cells[0].call(
       "exercise",
-      "create_cap_access",
+      "grant_p2p_message_cap",
       {
-        function: "receive_p2p_message",
         agent: bob_common.agent,
       }
     );
@@ -47,9 +46,8 @@ orchestrator.registerScenario(
     
     let capGrantBob = await bob_common.cells[0].call(
       "exercise",
-      "create_cap_access",
+      "grant_p2p_message_cap",
       {
-        function: "receive_p2p_message",
         agent: alice_common.agent,
       }
     );
@@ -59,9 +57,9 @@ orchestrator.registerScenario(
     //Create p2p post to bob
     let p2pPost2Bob = await alice_common.cells[0].call(
       "exercise",
-      "create_post",
+      "send_message",
       {
-        content: "Hey Bob!",
+        message: "Hey Bob!",
         target_agent: bob_common.agent,
       }
     );
@@ -71,7 +69,7 @@ orchestrator.registerScenario(
     //Check that bob has the p2p post
     let bobMessages = await bob_common.cells[0].call(
       "exercise",
-      "get_my_posts",
+      "get_messages",
       null
     );
     console.log(bobMessages);
@@ -81,9 +79,9 @@ orchestrator.registerScenario(
     //Create p2p post to alice
     let p2pPost2Alice = await bob_common.cells[0].call(
       "exercise",
-      "create_post",
+      "send_message",
       {
-        content: "Hey Alice!",
+        message: "Hey Alice!",
         target_agent: alice_common.agent,
       }
     );
@@ -93,26 +91,28 @@ orchestrator.registerScenario(
     //Check that alice has the p2p post
     let aliceMessages = await alice_common.cells[0].call(
       "exercise",
-      "get_my_posts",
+      "get_messages",
       null
     );
     console.log(aliceMessages);
     t.ok(aliceMessages);
     t.equal(aliceMessages.length, 1);
     
-    //Check that clare cannot message alice since she does not have cap access
-        // TODO add test that validates if the async function throws error
-        // -- commenting this out to make the CI build pass
-    // let p2pPost2Alice2 = await clare_common.cells[0].call(
-    //   "exercise",
-    //   "create_post",
-    //   {
-    //     content: "Hey Alice!",
-    //     target_agent: alice_common.agent,
-    //   }
-    // );
-    // console.log(p2pPost2Alice2);
-    // t.equal(p2pPost2Alice2.Err)
+    // Check that clare cannot message alice since she does not have cap access
+    try {
+      await clare_common.cells[0].call(
+        "exercise",
+        "send_unauthorized_message",
+        {
+          message: "Hey Alice!",
+          target_agent: alice_common.agent,
+        }
+      );
+      t.fail("The call should not have succeeded.");
+    } catch (err) {
+      console.log({err});
+      t.ok(err.data.data.includes("Unauthorized"));
+    }
   }
 );
 

--- a/2.intermediate/4.remote-call/solution/zomes/exercise/src/lib.rs
+++ b/2.intermediate/4.remote-call/solution/zomes/exercise/src/lib.rs
@@ -1,138 +1,201 @@
 use hdk::prelude::*;
 
-entry_defs![Post::entry_def()];
+entry_defs![Message::entry_def()];
 
-#[hdk_entry(id = "post", visibility = "private")]
-#[derive(Clone)]
-pub struct Post(String);
-
-#[hdk_extern]
-fn init(_: ()) -> ExternResult<InitCallbackResult> {
-    // grant unrestricted access to accept_cap_claim so other agents can send us claims
-    let mut functions: GrantedFunctions = BTreeSet::new();
-    functions.insert((zome_info()?.name, "receive_cap_access".into()));
-    create_cap_grant(CapGrantEntry {
-        tag: "".into(),
-        // empty access converts to unrestricted
-        access: ().into(),
-        functions,
-    })?;
-
-    Ok(InitCallbackResult::Pass)
-}
+/// The tag of CapGrants to send messages.
+/// 
+/// This would allow us to distinguish between grants for this zome and
+/// other zomes.
+const SEND_PEER_MESSAGE_CAP_GRANT_TAG: &str = "send_peer_message";
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct CreatePostInput {
-    content: String,
-    target_agent: AgentPubKey,
-}
-
-#[hdk_extern]
-pub fn create_post(create_input: CreatePostInput) -> ExternResult<CreatePostInput> {
-    //Get the cap claim from local private chain
-    let cap_secret = query(
-        ChainQueryFilter::new()
-            .entry_type(EntryType::CapClaim)
-            .include_entries(true),
-    )?
-    .into_iter()
-    .map(|elem| {
-        elem.entry()
-            .to_owned()
-            .into_option()
-            .unwrap()
-            .as_cap_claim()
-            .expect("Could not get option")
-            .to_owned()
-    })
-    .filter(|grant| grant.grantor() == &create_input.target_agent)
-    .collect::<Vec<CapClaim>>()
-    .pop()
-    .ok_or(WasmError::Host(
-        "No cap claim was found for desired target agent".to_string(),
-    ))?;
-
-    //Call remote function of target agent using secret found in cap claim
-    call_remote(
-        create_input.target_agent.clone(),
-        zome_info()?.name,
-        "receive_p2p_message".into(),
-        Some(cap_secret.secret().to_owned()),
-        Post(create_input.content.clone()),
-    )?;
-    Ok(create_input)
-}
-
-#[hdk_extern]
-pub fn receive_p2p_message(post: Post) -> ExternResult<()> {
-    create_entry(post.clone())?;
-    Ok(())
-}
-
-#[hdk_extern]
-pub fn get_my_posts(_: ()) -> ExternResult<Vec<Post>> {
-    let entry_def = Post::entry_def();
-    let posts = query(
-        ChainQueryFilter::new()
-            .entry_type(EntryType::App(AppEntryType::new(
-                0.into(),
-                zome_info()?.id,
-                entry_def.visibility,
-            )))
-            .include_entries(true),
-    )?
-    .into_iter()
-    .map(|elem| elem.entry().to_app_option::<Post>().unwrap().unwrap())
-    .collect::<Vec<Post>>();
-    Ok(posts)
+pub struct GrantPeerMessageCapInput {
+    pub agent: AgentPubKey,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CapReceive {
+pub struct CapSecretInput {
     pub cap_secret: CapSecret,
     pub from_agent: AgentPubKey,
 }
 
-#[hdk_extern]
-pub fn receive_cap_access(cap: CapReceive) -> ExternResult<()> {
-    create_cap_claim(CapClaimEntry::new(
-        "p2p_message".into(),
-        cap.from_agent,
-        cap.cap_secret,
-    ))?;
-    Ok(())
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct GrantCapAccess {
-    pub function: String,
-    pub agent: AgentPubKey,
+pub struct SendMessageInput {
+    message: Message,
+    target_agent: AgentPubKey,
 }
 
-#[hdk_extern]
-pub fn create_cap_access(access: GrantCapAccess) -> ExternResult<GrantCapAccess> {
-    //Create function map of cap grant
-    let mut functions: GrantedFunctions = BTreeSet::new();
-    functions.insert((zome_info()?.name, access.function.clone().into()));
+/// A message from one agent to another
+#[hdk_entry(id = "post", visibility = "private")]
+#[derive(Clone)]
+pub struct Message(String);
 
-    //Create the cap grant and commit for current agent
+#[hdk_extern]
+fn init(_: ()) -> ExternResult<InitCallbackResult> {
+    // Allow any agent to send us capabilities to send them messages
+    create_unrestricted_grant("receive_peer_message_cap_secret")?;
+    Ok(InitCallbackResult::Pass)
+}
+
+/// Directs this Agent to grant `input.agent` the capability to send messages
+#[hdk_extern]
+pub fn grant_peer_message_cap(input: GrantPeerMessageCapInput) -> ExternResult<GrantPeerMessageCapInput> {
+    let mut functions: GrantedFunctions = BTreeSet::new();
+    functions.insert((zome_info()?.name, "receive_peer_message".into()));
+
+    // Record that the agent can call these functions
     let cap_secret = generate_cap_secret()?;
     create_cap_grant(CapGrantEntry {
-        tag: "cap_grant".into(),
-        access: CapAccess::from((cap_secret, access.agent.clone())),
+        tag: SEND_PEER_MESSAGE_CAP_GRANT_TAG.into(),
+        access: CapAccess::from((cap_secret, input.agent.clone())),
         functions,
     })?;
 
-    //Call the zome of target agent and give them the generated cap secret
+    // Call the zome of target agent and give them the generated cap secret
     call_remote(
-        access.agent.clone(),
+        input.agent.clone(),
         zome_info()?.name,
-        "receive_cap_access".into(),
+        "receive_peer_message_cap_secret".into(),
         None,
-        CapReceive {
+        CapSecretInput {
             cap_secret: cap_secret,
             from_agent: agent_info()?.agent_initial_pubkey,
         },
     )?;
-    Ok(access)
+    Ok(input)
+}
+
+/// Receive the capability to message another agent.
+/// 
+/// Any agent can call this zome function.
+#[hdk_extern]
+pub fn receive_peer_message_cap_secret(input: CapSecretInput) -> ExternResult<()> {
+    create_cap_claim(CapClaimEntry {
+        tag: SEND_PEER_MESSAGE_CAP_GRANT_TAG.into(),
+        grantor: input.from_agent,
+        secret: input.cap_secret,
+    })?;
+    Ok(())
+}
+
+/// Sends a remote message with the given content and recipient
+#[hdk_extern]
+pub fn send_message(input: SendMessageInput) -> ExternResult<SendMessageInput> {
+    //Get the cap claim from local private chain
+    let cap_claim = get_cap_claim(&input.target_agent, SEND_PEER_MESSAGE_CAP_GRANT_TAG)?;
+
+    // Call remote function of target agent using secret found in cap claim
+    match zome_call_error_message(call_remote(
+        input.target_agent.clone(),
+        zome_info()?.name,
+        "receive_peer_message".into(),
+        Some(cap_claim.secret().to_owned()),
+        input.message.clone(),
+    )?) {
+        Ok(()) => Ok(input),
+        Err(message) => Err(WasmError::Guest(message))
+    }
+}
+
+/// Sends a remote message without valid CapClaim
+/// 
+/// This is just for testing.
+#[hdk_extern]
+pub fn send_unauthorized_message(input: SendMessageInput) -> ExternResult<SendMessageInput> {
+    // Make up a cap secret
+    let cap_secret = generate_cap_secret()?;
+
+    match zome_call_error_message(call_remote(
+        input.target_agent.clone(),
+        zome_info()?.name,
+        "receive_peer_message".into(),
+        Some(cap_secret),
+        input.message.clone(),
+    )?) {
+        Ok(()) => Ok(input),
+        Err(message) => Err(WasmError::Guest(message))
+    }
+}
+
+#[hdk_extern]
+pub fn receive_peer_message(message: Message) -> ExternResult<()> {
+    create_entry(message)?;
+    Ok(())
+}
+
+#[hdk_extern]
+pub fn get_messages(_: ()) -> ExternResult<Vec<Message>> {
+    get_all_entries::<Message>()
+}
+
+fn get_all_entries<T: EntryDefRegistration + TryFrom<SerializedBytes, Error = SerializedBytesError>>() -> ExternResult<Vec<T>> {
+    let entry_def = T::entry_def();
+    let entries = query(
+        ChainQueryFilter::new()
+            .entry_type(EntryType::App(AppEntryType::new(
+                entry_def_index!(T)?,
+                zome_info()?.id,
+                entry_def.visibility,
+            )))
+            .include_entries(true),
+        )?
+        .into_iter()
+        .map(|elem| elem.entry().to_app_option::<T>().unwrap().unwrap())
+        .collect::<Vec<T>>();
+    Ok(entries)
+}
+
+fn create_unrestricted_grant(fn_name: &str) -> ExternResult<HeaderHash> {
+    let mut functions: GrantedFunctions = BTreeSet::new();
+    functions.insert((zome_info()?.name, fn_name.into()));
+    create_cap_grant(CapGrantEntry {
+        tag: "".into(),
+        access: CapAccess::Unrestricted,
+        functions,
+    })
+}
+
+/// Returns the CapClaim with the grantor and tag
+fn get_cap_claim(grantor_hash: &AgentPubKey, tag: &str) -> ExternResult<CapClaim> {
+    query(
+        ChainQueryFilter::new()
+            .entry_type(EntryType::CapClaim)
+            .include_entries(true),
+    )?
+        .into_iter()
+        .map(|elem| {
+            elem.entry()
+                .to_owned()
+                .into_option()
+                .unwrap()
+                .as_cap_claim()
+                .expect("Could not get option")
+                .to_owned()
+        })
+        .filter(|grant|
+            // We only want a grant for messaging the agent
+            grant.grantor() == grantor_hash && 
+            grant.tag == tag)
+        .collect::<Vec<CapClaim>>()
+        .pop()
+        .ok_or(WasmError::Host(
+            "No CapClaim for messaging the agent was found".to_string(),
+        ))
+}
+
+/// Returns an error string for the ZomeCallResponse, if any
+fn zome_call_error_message(response: ZomeCallResponse) -> Result<(), String> {
+    let result = match response {
+        ZomeCallResponse::Ok(_) => Ok(()),
+        r @ ZomeCallResponse::Unauthorized(_, _, _, _) => 
+            Err(format!("Unauthorized remote call {r:?}")),
+        ZomeCallResponse::NetworkError(m) => 
+            Err(format!("Network error during remote call: {m:?}")),
+        ZomeCallResponse::CountersigningSession(m) => 
+            Err(format!("Counter signing session failed to start: {m:?}")),
+    };
+    match result {
+        Ok(()) => Ok(()),
+        Err(m) => Err(m),
+    }
 }


### PR DESCRIPTION
- Replace 'post' with 'message' since I think it fits the exercise better. 'Post' usually means something we create in a shared
  space (that may require permission to view) while a 'message' is something we send directly to another person.
- implement test for unauthorized access and include example of parsing ZomeCallResponse.
- remove `function` from GrantCapAccess and limit the cap grants just the receive_peer_message function.
- use helpers more to try and clarify what a zome function is doing.